### PR TITLE
Fix getParentTd in expand/collapse click by td

### DIFF
--- a/dataTables.treeGrid.js
+++ b/dataTables.treeGrid.js
@@ -283,7 +283,7 @@
     }
 
     function getParentTd(target) {
-        return $(target).parents('td')[0];
+        return target.tagName === 'TD' ? target : $(target).parents('td')[0];
     }
 
     TreeGrid.defaults = {


### PR DESCRIPTION
Fixed click by TD element. Issue was in incorrect work of "getParentTd" method. It searched  TR element instead of TD. 